### PR TITLE
Changed  generate_password_hash from sha256 to scrypt

### DIFF
--- a/project/auth.py
+++ b/project/auth.py
@@ -48,7 +48,7 @@ def signup_post():
         return redirect(url_for('auth.signup'))
 
     # create new user with the form data. Hash the password so plaintext version isn't saved.
-    new_user = User(email=email, name=name, password=generate_password_hash(password, method='sha256'))
+    new_user = User(email=email, name=name, password=generate_password_hash(password, method='scrypt'))
 
     # add the new user to the database
     db.session.add(new_user)


### PR DESCRIPTION
**generate_password_hash** no longer supports the **sha256** method

The following methods are now supported:

**scrypt**, the default. The parameters are n, r, and p, the default is scrypt:32768:8:1. See [hashlib.scrypt()](https://docs.python.org/3/library/hashlib.html#hashlib.scrypt).

**pbkdf2**, less secure. The parameters are hash_method and iterations, the default is pbkdf2:sha256:600000. See [hashlib.pbkdf2_hmac()](https://docs.python.org/3/library/hashlib.html#hashlib.pbkdf2_hmac).